### PR TITLE
BUGFIX: don't throw an exception when a parent class is not set

### DIFF
--- a/code/Extensions/CatalogPageExtension.php
+++ b/code/Extensions/CatalogPageExtension.php
@@ -73,8 +73,6 @@ class CatalogPageExtension extends DataExtension
                 throw new Exception('You must create a parent page of class ' . implode(',', $parentClass));
             }
 
-        } else {
-            throw new Exception('Parent class ' . implode(',', $parentClass) . ' does not exist.');
         }
     }
 


### PR DESCRIPTION
Fixes #20 