### PR TITLE
Check page type before updating sort

### DIFF
--- a/code/ModelAdmin/CatalogPageAdmin.php
+++ b/code/ModelAdmin/CatalogPageAdmin.php
@@ -112,7 +112,9 @@ class CatalogPageAdmin extends ModelAdmin
         }
         if ($model::config()->get('automatic_live_sort') == true) {
             foreach ($pages as $page) {
-                DB::query("UPDATE " . $modelClass . "_Live SET " . $model->getSortFieldname() . "=" . $page->{$model->getSortFieldname()} . " WHERE ID=" . $page->ID);
+                if(get_class($page) == $modelClass) {
+                    DB::query("UPDATE " . $modelClass . "_Live SET " . $model->getSortFieldname() . "=" . $page->{$model->getSortFieldname()} . " WHERE ID=" . $page->ID);
+                }
             }
         }
 


### PR DESCRIPTION
Check if we are modifying the correct table before updating the sort order. Fixes issue caused by sorting data objects in a sortable grid field.