### PR TITLE
Fixing automatic-sort of SiteTree subclasses.

### DIFF
--- a/code/ModelAdmin/CatalogPageAdmin.php
+++ b/code/ModelAdmin/CatalogPageAdmin.php
@@ -112,7 +112,7 @@ class CatalogPageAdmin extends ModelAdmin
         }
         if ($model::config()->get('automatic_live_sort') == true) {
             foreach ($pages as $page) {
-                if(get_class($page) == $modelClass) {
+                if($page instanceof $modelClass) {
                     DB::query("UPDATE " . $modelClass . "_Live SET " . $model->getSortFieldname() . "=" . $page->{$model->getSortFieldname()} . " WHERE ID=" . $page->ID);
                 }
             }


### PR DESCRIPTION
Since the modelClass is being reset to `SiteTree` ([Line 111 in CatalogPageAdmin.php](https://github.com/Little-Giant/silverstripe-catalogmanager/blob/master/code/ModelAdmin/CatalogPageAdmin.php#L111)), a string comparison is therefore not enough to check for subclasses of SiteTree (eg. if your model is something like `BlogPage`, the existing comparison will always fail, thus rendering automatic-live-sorting unusable).