### PR TITLE
BUG FIX: allow null parent

### DIFF
--- a/code/Extensions/CatalogPageExtension.php
+++ b/code/Extensions/CatalogPageExtension.php
@@ -84,7 +84,7 @@ class CatalogPageExtension extends DataExtension
     {
         $parentClasses = $this->owner->stat('parentClass');
 
-        if(!is_array($parentClasses)) {
+        if(!is_array($parentClasses) && $parentClasses != null) {
             return array($parentClasses);
         }
 


### PR DESCRIPTION
Fixes a bug introduced in #35 when no parent has been specified.