### PR TITLE
UPDATE: Refactored translation extension

### DIFF
--- a/code/templates/ModelAdmin_Tools.ss
+++ b/code/templates/ModelAdmin_Tools.ss
@@ -1,0 +1,20 @@
+<div class="cms-content-tools west cms-panel cms-panel-layout" id="cms-content-tools-ModelAdmin" data-expandOnClick="true" data-layout-type="border">
+    <div class="cms-panel-content center">
+        <% if $SearchForm %>
+            <h3 class="cms-panel-header"><% _t('ModelAdmin_Tools_ss.FILTER', 'Filter') %></h3>
+            $SearchForm
+        <% end_if %>
+
+        <% if $ImportForm %>
+            <h3 class="cms-panel-header"><% _t('ModelAdmin_Tools_ss.IMPORT', 'Import') %></h3>
+            $ImportForm
+        <% end_if %>
+        <% if $LanguageSelectorForm %>
+            <h3 class="cms-panel-header"><% _t('ModelAdmin_Tools_ss.LANGUAGE', 'Language') %></h3>
+            $LanguageSelectorForm
+        <% end_if %>
+    </div>
+    <div class="cms-panel-content-collapsed">
+        <h3 class="cms-panel-header"><% _t('ModelAdmin_Tools_ss.FILTER', 'Filter') %></h3>
+    </div>
+</div>


### PR DESCRIPTION
This moves the `LanguageDropdownField` into its own form. Fixes #43 and also retains the import form.