### PR TITLE
Fixes to be more compatible with Translatable module's javascript

### DIFF
--- a/code/Extensions/TranslatableCatalogExtension.php
+++ b/code/Extensions/TranslatableCatalogExtension.php
@@ -9,9 +9,9 @@ class TranslatableCatalogExtension extends Extension
     /**
      * @var array
      */
-    private static $allowed_actions = [
+    private static $allowed_actions = array(
         'language'
-    ];
+	);
 
     /**
      * @return mixed
@@ -72,7 +72,7 @@ class TranslatableCatalogExtension extends Extension
         $fields = FieldList::create($this->getLanguageField());
         return Form::create(
             $this->owner,
-            'language',
+            'LangForm',
             $fields,
             FieldList::create(FormAction::create(
                 'language',

--- a/code/Extensions/TranslatableCatalogExtension.php
+++ b/code/Extensions/TranslatableCatalogExtension.php
@@ -7,13 +7,6 @@ class TranslatableCatalogExtension extends Extension
 {
 
     /**
-     * @var array
-     */
-    private static $allowed_actions = array(
-        'language'
-	);
-
-    /**
      * @return mixed
      */
     public function language()

--- a/code/templates/ModelAdmin_Tools.ss
+++ b/code/templates/ModelAdmin_Tools.ss
@@ -11,7 +11,9 @@
         <% end_if %>
         <% if $LanguageSelectorForm %>
             <h3 class="cms-panel-header"><% _t('ModelAdmin_Tools_ss.LANGUAGE', 'Language') %></h3>
-            $LanguageSelectorForm
+			<div class="CMSMain">
+				$LanguageSelectorForm
+			</div>
         <% end_if %>
     </div>
     <div class="cms-panel-content-collapsed">


### PR DESCRIPTION
Change name of language form to "LangForm" and added a CSS class to the modeladmin template, so that translatables javascript will still work as it should. Also changed an array to old syntax so that it works with php 5.3