### PR TITLE
CMS 5 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
         }
     ],
     "require": {
-        "silverstripe/cms": "^4.0",
-        "symbiote/silverstripe-gridfieldextensions": "^3.2"
+        "silverstripe/cms": "^5.0.0",
+        "symbiote/silverstripe-gridfieldextensions": "^4.0.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Extensions/AutoPublishSortExtension.php
+++ b/src/Extensions/AutoPublishSortExtension.php
@@ -37,7 +37,7 @@ class AutoPublishSortExtension extends Extension
         foreach ($sortedIDs as $sortValue => $itemID) {
             DB::prepared_query('UPDATE "' . $tableName . '_Live" SET "' . $sortField . '"=? WHERE "ID"=?', [$sortValue, $itemID]);
             $version = DB::prepared_query('SELECT Version FROM "' . $tableName . '_Versions" WHERE "RecordID"=? ORDER BY "ID" DESC', [$itemID]);
-            DB::prepared_query('UPDATE "' . $tableName . '_Live" SET "Version"=? WHERE "ID"=?', [$version->first()['Version'], $itemID]);
+            DB::prepared_query('UPDATE "' . $tableName . '_Live" SET "Version"=? WHERE "ID"=?', [$version->record()['Version'], $itemID]);
         }
     }
 }

--- a/src/Extensions/CategoryPageHierarchyExtension.php
+++ b/src/Extensions/CategoryPageHierarchyExtension.php
@@ -20,7 +20,7 @@ class CategoryPageHierarchyExtension extends DataExtension
      * @param \SilverStripe\ORM\DataList $stageChildren
      * @param $context
      */
-    public function augmentAllChildrenIncludingDeleted(&$stageChildren, &$context)
+    public function augmentAllChildrenIncludingDeleted(&$stageChildren)
     {
         if ($this->shouldFilter() && $this->owner->hasExtension(HidePageChildrenExtension::class)) {
             $stageChildren = $stageChildren->exclude('ClassName', $this->getExcludedSiteTreeClassNames());


### PR DESCRIPTION
Updated composer.json to use package also on Silverstripe CMS ^5 projects.

Fixed Uncaught ArgumentCountError within `LittleGiant\CatalogManager\Extensions\CategoryPageHierarchyExtension` which is also mentions within Issue: https://github.com/isobar-nz/silverstripe-catalogmanager/issues/73
